### PR TITLE
bugfix: Docs missing some code for the Chat API

### DIFF
--- a/docs/sections/06-chat-api.md
+++ b/docs/sections/06-chat-api.md
@@ -187,6 +187,8 @@ import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import org.slf4j.Logger;


### PR DESCRIPTION
The Chat API that is built is missing some import statements. It's easy enough to find the issue yourself, but ensuring that the import statements are correct from the start helps remove doubt over whether someone is following steps correctly.